### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This repository contains **Dockerfile** of [Ubuntu Desktop (LXDE)](http://lxde.o
 
 ### Usage
 
-    docker run -it --rm -p 5901:5901 dockerfile/ubuntu-desktop \
-        USER=root vncserver :1 -geometry 1280x800 -depth 24
+    docker run -it --rm -p 5901:5901 -e USER=root dockerfile/ubuntu-desktop \
+        bash -c "vncserver :1 -geometry 1280x800 -depth 24 && tail -F /root/.vnc/*.log"
 
 Connect to `vnc://<host>:5901` via VNC client.


### PR DESCRIPTION
Print vnc log in foreground to keep docker container alive.
(Or the container will stop when vncserver process return.)
